### PR TITLE
Type safe routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-development-tools",
-  "version": "3.6.0",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-development-tools",
-      "version": "3.6.0",
+      "version": "3.6.2",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -4621,14 +4621,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/acorn": {
-      "version": "4.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.1",
       "dev": true,
@@ -5512,9 +5504,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11748,6 +11741,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-jsx/node_modules/@types/acorn": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
+      "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/micromark-extension-mdx-md": {
       "version": "1.0.1",
       "dev": true,
@@ -12079,6 +12081,15 @@
         "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0",
         "vfile-message": "^3.0.0"
+      }
+    },
+    "node_modules/micromark-util-events-to-acorn/node_modules/@types/acorn": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
+      "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/micromark-util-html-tag-name": {

--- a/src/RemixDevTools/vite/utils.ts
+++ b/src/RemixDevTools/vite/utils.ts
@@ -1,8 +1,9 @@
-import fs from "fs";
+import fs, { readFile } from "fs";
 import { join } from "path";
-
 import { IncomingMessage, ServerResponse } from "http";
 import { Connect } from "vite";
+import { Route, RouteManifest } from "@remix-run/server-runtime/dist/routes.js";
+import { writeFile } from "fs/promises";
 
 export function processPlugins(pluginDirectoryPath: string) {
   const files = fs.readdirSync(pluginDirectoryPath);
@@ -40,5 +41,75 @@ export const handleDevToolsViteRequest = (
     const parsedData = JSON.parse(dataToParse.toString());
     cb(parsedData);
     res.write("OK");
+  });
+};
+
+interface RouteTree {
+  id: string;
+  children?: RouteTree[];
+}
+
+const constructTree = (routes: Record<string, Route>, parentId?: string): RouteTree[] => {
+  const nodes: RouteTree[] = [];
+  Object.keys(routes).forEach((key) => {
+    const route = routes[key];
+    if (route.parentId === parentId) {
+      const node: RouteTree = {
+        ...route,
+        children: constructTree(routes, route.id),
+      };
+      nodes.push(node);
+    }
+  });
+  return nodes;
+};
+
+export const createRouteTree = (routes: RouteManifest<Route>) => constructTree(routes);
+
+export const createRouteTreeFromAst = (ast: any) => {
+  const namedExports = ast.body.filter((n: any) => n.type === "ExportNamedDeclaration");
+  // The properties exist but they are typed as they didn't exist
+  const routeExportNode = namedExports.find((n: any) => n.declaration?.declarations?.[0]?.id?.name === "routes");
+  // This gets the value of the object declaration (eg: const routes = { type: "" }) gets { type: "" }
+  const routeExportValue = routeExportNode?.declaration?.declarations?.[0].init;
+  // This creates an array of objects with the properties of the object declaration
+  const routeExportProperties = routeExportValue?.properties
+    .map((p: any) => {
+      // This gets the key and the value and creates an object out of the AST, eg: { key: "type", value: "module" }
+      const keyValuePairs: { key: string; value: string }[] = p?.value?.properties?.map((p: any) => {
+        return {
+          key: p?.key?.name,
+          value: p?.value?.value === "" ? "/" : p?.value?.value,
+        };
+      });
+      // This creates a route object out of the key value pairs, eg: { type: "module" }
+      const route = Object.fromEntries(keyValuePairs.map((v: { key: string; value: string }) => [v.key, v.value]));
+      // Get only the routes with actual path segments
+      if (route.path === undefined) {
+        return undefined;
+      }
+      return route;
+    })
+    .filter(Boolean);
+  // Converts the array of route objects into an object with the id as the key, eg: { "/": { type: "module", path: "blah" } }
+  const routes = Object.fromEntries(routeExportProperties.map((p: any) => [p.id, p]));
+  // Creates a tree out of the routes object
+  const routeTree = createRouteTree(routes);
+
+  return routeTree;
+};
+export const rewriteTypeFile = (fileRewriter: (file: string) => string, path: string, typeImport: string) => {
+  readFile(path, (err, data) => {
+    if (err) {
+      return;
+    }
+    const file = data.toString();
+    const hasImport = file.includes(typeImport);
+    if (hasImport) {
+      return;
+    }
+    const newFile = typeImport + "\n" + fileRewriter(file);
+
+    writeFile(path, newFile);
   });
 };

--- a/src/test-apps/remix-vite/app/routes/_index.tsx
+++ b/src/test-apps/remix-vite/app/routes/_index.tsx
@@ -22,7 +22,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 }; 
  
 export const action = async ({ request }: ActionFunctionArgs) => {
-  return redirect("/login");
+  return redirect("");
 };
  
 export default function Index() {  


### PR DESCRIPTION
# Description

Provides run-time type safety to useNavigate and redirect hook and function from remix.

The vite plugin parses the virtual server entry module and constructs the route object exported from the file and then uses that to construct a route tree and then does the following:
- writes the typed routes file into node_modules remix packages
- replaces the loosely typed string types from remix with the actual types that the user has in his app. 
 
# Issues to figure out
- Monorepo support => this outputs the files into the vites CWD node modules, if the modules are located in the parent directories in monorepos it wouldn't work
- Check if the user has the actual files => not sure if this one is needed but I think that every project has remix/server-runtime and router packages but I could be wrong
- Requirement to restart the TS server in VS code => whenever the write happens it is not registered by the typescript runner in vs code and you need to restart it for it to pick up the changes